### PR TITLE
selectorInSlotIndex optimization

### DIFF
--- a/contracts/libraries/LibDiamond.sol
+++ b/contracts/libraries/LibDiamond.sol
@@ -149,12 +149,13 @@ library LibDiamond {
             uint256 selectorSlotCount = _selectorCount / 8;
             uint256 selectorInSlotIndex = _selectorCount % 8;
             for (uint256 selectorIndex; selectorIndex < _selectors.length; selectorIndex++) {
-                selectorInSlotIndex--;
                 if (_selectorSlot == 0) {
                     // get last selectorSlot
                     selectorSlotCount--;
                     _selectorSlot = ds.selectorSlots[selectorSlotCount];
                     selectorInSlotIndex = 7;
+                } else {
+                    selectorInSlotIndex--;
                 }
                 bytes4 lastSelector;
                 uint256 oldSelectorsSlotCount;

--- a/contracts/libraries/LibDiamond.sol
+++ b/contracts/libraries/LibDiamond.sol
@@ -147,8 +147,9 @@ library LibDiamond {
         } else if (_action == IDiamondCut.FacetCutAction.Remove) {
             require(_newFacetAddress == address(0), "LibDiamondCut: Remove facet address must be address(0)");
             uint256 selectorSlotCount = _selectorCount / 8;
-            uint256 selectorInSlotIndex = (_selectorCount % 8) - 1;
+            uint256 selectorInSlotIndex = _selectorCount % 8;
             for (uint256 selectorIndex; selectorIndex < _selectors.length; selectorIndex++) {
+                selectorInSlotIndex--;
                 if (_selectorSlot == 0) {
                     // get last selectorSlot
                     selectorSlotCount--;
@@ -195,9 +196,8 @@ library LibDiamond {
                     delete ds.selectorSlots[selectorSlotCount];
                     _selectorSlot = 0;
                 }
-                selectorInSlotIndex--;
             }
-            _selectorCount = selectorSlotCount * 8 + selectorInSlotIndex + 1;
+            _selectorCount = selectorSlotCount * 8 + selectorInSlotIndex;
         } else {
             revert("LibDiamondCut: Incorrect FacetCutAction");
         }


### PR DESCRIPTION
This branch includes two changes:
1. fewer arithmetic operations resulting in slight gas savings
2. moving decrement to `else` statement, which does not save gas but will facilitate conversion to `0.8.x` by preventing underflow