### PR TITLE
remove check for zero address when code size is enforced

### DIFF
--- a/contracts/libraries/LibDiamond.sol
+++ b/contracts/libraries/LibDiamond.sol
@@ -112,7 +112,6 @@ library LibDiamond {
         DiamondStorage storage ds = diamondStorage();
         require(_selectors.length > 0, "LibDiamondCut: No selectors in facet to cut");
         if (_action == IDiamondCut.FacetCutAction.Add) {
-            require(_newFacetAddress != address(0), "LibDiamondCut: Add facet can't be address(0)");
             enforceHasContractCode(_newFacetAddress, "LibDiamondCut: Add facet has no code");
             for (uint256 selectorIndex; selectorIndex < _selectors.length; selectorIndex++) {
                 bytes4 selector = _selectors[selectorIndex];
@@ -131,7 +130,6 @@ library LibDiamond {
                 _selectorCount++;
             }
         } else if (_action == IDiamondCut.FacetCutAction.Replace) {
-            require(_newFacetAddress != address(0), "LibDiamondCut: Replace facet can't be address(0)");
             enforceHasContractCode(_newFacetAddress, "LibDiamondCut: Replace facet has no code");
             for (uint256 selectorIndex; selectorIndex < _selectors.length; selectorIndex++) {
                 bytes4 selector = _selectors[selectorIndex];


### PR DESCRIPTION
`enforceHasContractCode` will revert if passed the zero address.