### PR TITLE
Allow diamondCut to be extended in a derived facet

### DIFF
--- a/contracts/facets/DiamondCutFacet.sol
+++ b/contracts/facets/DiamondCutFacet.sol
@@ -21,7 +21,7 @@ contract DiamondCutFacet is IDiamondCut {
         FacetCut[] calldata _diamondCut,
         address _init,
         bytes calldata _calldata
-    ) external override {
+    ) public virtual override {
         LibDiamond.enforceIsContractOwner();
         LibDiamond.DiamondStorage storage ds = LibDiamond.diamondStorage();
         uint256 originalSelectorCount = ds.selectorCount;


### PR DESCRIPTION
This PR updates the visibility of the `diamondCut` method in `DiamondCutFacet` from external to public and adds the virtual keyword. This change enables the method to be overridden and extended in a derived facet. 

Open to discussing suggested patterns for extending `diamondCut` functionality if this is not recommended. Thank you so much!